### PR TITLE
Add descriptive alt text to portfolio images

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -429,7 +429,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/amg-centre.1a16e993.png">
+                                                                <img class="js-lazy" data-original="images/portfolio/amg-centre.1a16e993.png" alt="AMG Centre website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -447,7 +447,7 @@
 						<div id="amg-centre" class="js-modal modal">
 							<div class="modal-content">
 								<h4>مرکز خدمات مرسدس بنز</h4>
-								<img class="responsive-img" src="images/portfolio/amg-centre.1a16e993.png">
+                                                                <img class="responsive-img" src="images/portfolio/amg-centre.1a16e993.png" alt="AMG Centre website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -464,7 +464,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/tavanito.d8f06cd0.png">
+                                                                <img class="js-lazy" data-original="images/portfolio/tavanito.d8f06cd0.png" alt="Tavanito website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -482,7 +482,7 @@
 						<div id="tavanito" class="js-modal modal">
 							<div class="modal-content">
 								<h4>توانیتو</h4>
-								<img class="responsive-img" src="images/portfolio/tavanito.d8f06cd0.png">
+                                                                <img class="responsive-img" src="images/portfolio/tavanito.d8f06cd0.png" alt="Tavanito website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -510,7 +510,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/90tv.605301f7.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/90tv.605301f7.jpeg" alt="90TV sports program website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -528,7 +528,7 @@
 						<div id="90tv" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت برنامه ورزشی نود</h4>
-								<img class="responsive-img" src="images/portfolio/90tv.605301f7.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/90tv.605301f7.jpeg" alt="90TV sports program website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -559,7 +559,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/fanap.en.3928eda6.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/fanap.en.3928eda6.jpeg" alt="Fanap company website screenshot (English)">
 							</div>						
 							<div class="card-content">
 								<div class="card-title">
@@ -577,7 +577,7 @@
 						<div id="fanapen" class="js-modal modal">
 							<div class="modal-content">
 								<h4>نسخه انگلیسی وب‌سایت شرکت فناپ</h4>
-								<img class="responsive-img" src="images/portfolio/fanap.en.3928eda6.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/fanap.en.3928eda6.jpeg" alt="Fanap company website screenshot (English)">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -620,7 +620,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/fanap.en.innovation.aba4c0cd.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/fanap.en.innovation.aba4c0cd.jpeg" alt="Fanap Innovation Center page screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -638,7 +638,7 @@
 						<div id="fanapeninnovation" class="js-modal modal">
 							<div class="modal-content">
 								<h4>صفحه اختصاصی مرکز نوآوری فناپ</h4>
-								<img class="responsive-img" src="images/portfolio/fanap.en.innovation.aba4c0cd.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/fanap.en.innovation.aba4c0cd.jpeg" alt="Fanap Innovation Center page screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -681,7 +681,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/fanap.fa.525ce0c8.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/fanap.fa.525ce0c8.jpeg" alt="Fanap company website screenshot (Persian)">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -699,7 +699,7 @@
 						<div id="fanapfa" class="js-modal modal">
 							<div class="modal-content">
 								<h4>نسخه فارسی وب‌سایت شرکت فناپ</h4>
-								<img class="responsive-img" src="images/portfolio/fanap.fa.525ce0c8.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/fanap.fa.525ce0c8.jpeg" alt="Fanap company website screenshot (Persian)">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -742,7 +742,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/faranegar.8bed654d.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/faranegar.8bed654d.jpeg" alt="Faranegar company website screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -759,7 +759,7 @@
 						<div id="faranegar" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت شرکت فرانگار</h4>
-								<img class="responsive-img" src="images/portfolio/faranegar.8bed654d.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/faranegar.8bed654d.jpeg" alt="Faranegar company website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -802,7 +802,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/ketabgallery.51e3f237.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/ketabgallery.51e3f237.jpeg" alt="Ketab Gallery online bookstore screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -820,7 +820,7 @@
 						<div id="ketabgallery" class="js-modal modal">
 							<div class="modal-content">
 								<h4>فروشگاه اینترنتی گالری کتاب</h4>
-								<img class="responsive-img" src="images/portfolio/ketabgallery.51e3f237.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/ketabgallery.51e3f237.jpeg" alt="Ketab Gallery online bookstore screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -854,7 +854,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/fozhanpub.8b79397e.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/fozhanpub.8b79397e.jpeg" alt="Fozhan Publishing online store screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -872,7 +872,7 @@
 						<div id="fozhanpub" class="js-modal modal">
 							<div class="modal-content">
 								<h4>فروشگاه اینترنتی انتشارات فوژان</h4>
-								<img class="responsive-img" src="images/portfolio/fozhanpub.8b79397e.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/fozhanpub.8b79397e.jpeg" alt="Fozhan Publishing online store screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -906,7 +906,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/hcm.bpi.56e5c088.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/hcm.bpi.56e5c088.jpeg" alt="Bank Pasargad employee portal screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -923,7 +923,7 @@
 						<div id="hcmbpi" class="js-modal modal">
 							<div class="modal-content">
 								<h4>پرتال کارکنان بانک پاسارگاد</h4>
-								<img class="responsive-img" src="images/portfolio/hcm.bpi.56e5c088.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/hcm.bpi.56e5c088.jpeg" alt="Bank Pasargad employee portal screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -954,7 +954,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/parsaryan.b9bf4af3.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/parsaryan.b9bf4af3.jpeg" alt="Parsaryan investment company website screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -972,7 +972,7 @@
 						<div id="parsaryan" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت شرکت شرکت سرمایه گذاری پارس آریان</h4>
-								<img class="responsive-img" src="images/portfolio/parsaryan.b9bf4af3.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/parsaryan.b9bf4af3.jpeg" alt="Parsaryan investment company website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1015,7 +1015,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/bpikids.8228c3e8.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/bpikids.8228c3e8.jpeg" alt="Pasargad Bank Kids website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -1033,7 +1033,7 @@
 						<div id="bpikids" class="js-modal modal">
 							<div class="modal-content">
 								<h4>سامانه کودک بانک پاسارگاد</h4>
-								<img class="responsive-img" src="images/portfolio/bpikids.8228c3e8.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/bpikids.8228c3e8.jpeg" alt="Pasargad Bank Kids website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1055,7 +1055,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/planno.5ad07b25.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/planno.5ad07b25.jpeg" alt="Mohammad Moradian personal website screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -1073,7 +1073,7 @@
 						<div id="planno" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت شخصی مهندس محمد مرادیان</h4>
-								<img class="responsive-img" src="images/portfolio/planno.5ad07b25.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/planno.5ad07b25.jpeg" alt="Mohammad Moradian personal website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1101,7 +1101,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/isohse.44f2c597.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/isohse.44f2c597.jpeg" alt="ISOHSE institute website screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -1118,7 +1118,7 @@
 						<div id="planno" class="js-modal modal">
 							<div class="modal-content">
 								<h4>موسسه ایمنی و بهداشت کار پایدار</h4>
-								<img class="responsive-img" src="images/portfolio/isohse.44f2c597.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/isohse.44f2c597.jpeg" alt="ISOHSE institute website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1137,7 +1137,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/archipars.48043c37.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/archipars.48043c37.jpeg" alt="Archipars company website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -1155,7 +1155,7 @@
 						<div id="archipars" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت شرکت آرشی پارس</h4>
-								<img class="responsive-img" src="images/portfolio/archipars.48043c37.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/archipars.48043c37.jpeg" alt="Archipars company website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1241,7 +1241,7 @@
 				<ul class="o-collection collection card">
 					<li class="o-collectionItem collection-item">
 						<div class="right">
-							<img src="images/awards/ux95.1838d210.jpg" class="o-collectionImage circle">
+                                                        <img src="images/awards/ux95.1838d210.jpg" class="o-collectionImage circle" alt="UX95 user experience award logo">
 						</div>
 						<div class="o-collectionValignWrapper">
 							<div class="o-collectionValignBox">

--- a/src/index.html
+++ b/src/index.html
@@ -427,7 +427,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/amg-centre.png">
+                                                                <img class="js-lazy" data-original="images/portfolio/amg-centre.png" alt="AMG Centre website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -445,7 +445,7 @@
 						<div id="amg-centre" class="js-modal modal">
 							<div class="modal-content">
 								<h4>مرکز خدمات مرسدس بنز</h4>
-								<img class="responsive-img" src="images/portfolio/amg-centre.png">
+                                                                <img class="responsive-img" src="images/portfolio/amg-centre.png" alt="AMG Centre website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -462,7 +462,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/tavanito.png">
+                                                                <img class="js-lazy" data-original="images/portfolio/tavanito.png" alt="Tavanito website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -480,7 +480,7 @@
 						<div id="tavanito" class="js-modal modal">
 							<div class="modal-content">
 								<h4>توانیتو</h4>
-								<img class="responsive-img" src="images/portfolio/tavanito.png">
+                                                                <img class="responsive-img" src="images/portfolio/tavanito.png" alt="Tavanito website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -508,7 +508,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/90tv.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/90tv.jpeg" alt="90TV sports program website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -526,7 +526,7 @@
 						<div id="90tv" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت برنامه ورزشی نود</h4>
-								<img class="responsive-img" src="images/portfolio/90tv.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/90tv.jpeg" alt="90TV sports program website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -557,7 +557,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/fanap.en.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/fanap.en.jpeg" alt="Fanap company website screenshot (English)">
 							</div>						
 							<div class="card-content">
 								<div class="card-title">
@@ -575,7 +575,7 @@
 						<div id="fanapen" class="js-modal modal">
 							<div class="modal-content">
 								<h4>نسخه انگلیسی وب‌سایت شرکت فناپ</h4>
-								<img class="responsive-img" src="images/portfolio/fanap.en.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/fanap.en.jpeg" alt="Fanap company website screenshot (English)">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -618,7 +618,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/fanap.en.innovation.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/fanap.en.innovation.jpeg" alt="Fanap Innovation Center page screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -636,7 +636,7 @@
 						<div id="fanapeninnovation" class="js-modal modal">
 							<div class="modal-content">
 								<h4>صفحه اختصاصی مرکز نوآوری فناپ</h4>
-								<img class="responsive-img" src="images/portfolio/fanap.en.innovation.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/fanap.en.innovation.jpeg" alt="Fanap Innovation Center page screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -679,7 +679,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/fanap.fa.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/fanap.fa.jpeg" alt="Fanap company website screenshot (Persian)">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -697,7 +697,7 @@
 						<div id="fanapfa" class="js-modal modal">
 							<div class="modal-content">
 								<h4>نسخه فارسی وب‌سایت شرکت فناپ</h4>
-								<img class="responsive-img" src="images/portfolio/fanap.fa.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/fanap.fa.jpeg" alt="Fanap company website screenshot (Persian)">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -740,7 +740,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/faranegar.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/faranegar.jpeg" alt="Faranegar company website screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -757,7 +757,7 @@
 						<div id="faranegar" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت شرکت فرانگار</h4>
-								<img class="responsive-img" src="images/portfolio/faranegar.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/faranegar.jpeg" alt="Faranegar company website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -800,7 +800,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/ketabgallery.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/ketabgallery.jpeg" alt="Ketab Gallery online bookstore screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -818,7 +818,7 @@
 						<div id="ketabgallery" class="js-modal modal">
 							<div class="modal-content">
 								<h4>فروشگاه اینترنتی گالری کتاب</h4>
-								<img class="responsive-img" src="images/portfolio/ketabgallery.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/ketabgallery.jpeg" alt="Ketab Gallery online bookstore screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -852,7 +852,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/fozhanpub.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/fozhanpub.jpeg" alt="Fozhan Publishing online store screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -870,7 +870,7 @@
 						<div id="fozhanpub" class="js-modal modal">
 							<div class="modal-content">
 								<h4>فروشگاه اینترنتی انتشارات فوژان</h4>
-								<img class="responsive-img" src="images/portfolio/fozhanpub.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/fozhanpub.jpeg" alt="Fozhan Publishing online store screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -904,7 +904,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/hcm.bpi.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/hcm.bpi.jpeg" alt="Bank Pasargad employee portal screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -921,7 +921,7 @@
 						<div id="hcmbpi" class="js-modal modal">
 							<div class="modal-content">
 								<h4>پرتال کارکنان بانک پاسارگاد</h4>
-								<img class="responsive-img" src="images/portfolio/hcm.bpi.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/hcm.bpi.jpeg" alt="Bank Pasargad employee portal screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -952,7 +952,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/parsaryan.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/parsaryan.jpeg" alt="Parsaryan investment company website screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -970,7 +970,7 @@
 						<div id="parsaryan" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت شرکت شرکت سرمایه گذاری پارس آریان</h4>
-								<img class="responsive-img" src="images/portfolio/parsaryan.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/parsaryan.jpeg" alt="Parsaryan investment company website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1013,7 +1013,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/bpikids.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/bpikids.jpeg" alt="Pasargad Bank Kids website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -1031,7 +1031,7 @@
 						<div id="bpikids" class="js-modal modal">
 							<div class="modal-content">
 								<h4>سامانه کودک بانک پاسارگاد</h4>
-								<img class="responsive-img" src="images/portfolio/bpikids.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/bpikids.jpeg" alt="Pasargad Bank Kids website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1053,7 +1053,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/planno.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/planno.jpeg" alt="Mohammad Moradian personal website screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -1071,7 +1071,7 @@
 						<div id="planno" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت شخصی مهندس محمد مرادیان</h4>
-								<img class="responsive-img" src="images/portfolio/planno.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/planno.jpeg" alt="Mohammad Moradian personal website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1099,7 +1099,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/isohse.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/isohse.jpeg" alt="ISOHSE institute website screenshot">
 							</div>							
 							<div class="card-content">
 								<div class="card-title">
@@ -1116,7 +1116,7 @@
 						<div id="planno" class="js-modal modal">
 							<div class="modal-content">
 								<h4>موسسه ایمنی و بهداشت کار پایدار</h4>
-								<img class="responsive-img" src="images/portfolio/isohse.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/isohse.jpeg" alt="ISOHSE institute website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1135,7 +1135,7 @@
 					<div class="col s12 m6">
 						<div class="card">
 							<div class="c-portfolio__image card-image">
-								<img class="js-lazy" data-original="images/portfolio/archipars.jpeg">
+                                                                <img class="js-lazy" data-original="images/portfolio/archipars.jpeg" alt="Archipars company website screenshot">
 							</div>
 							<div class="card-content">
 								<div class="card-title">
@@ -1153,7 +1153,7 @@
 						<div id="archipars" class="js-modal modal">
 							<div class="modal-content">
 								<h4>وب‌سایت شرکت آرشی پارس</h4>
-								<img class="responsive-img" src="images/portfolio/archipars.jpeg">
+                                                                <img class="responsive-img" src="images/portfolio/archipars.jpeg" alt="Archipars company website screenshot">
 								<p class="grey-text text-darken-1">تکنولوژی و مهارت های به کار گرفته شده در این پروژه</p>
 								<div class="left-align">
 									<div class="chip">
@@ -1239,7 +1239,7 @@
 				<ul class="o-collection collection card">
 					<li class="o-collectionItem collection-item">
 						<div class="right">
-							<img src="images/awards/ux95.jpg" class="o-collectionImage circle">
+                                                        <img src="images/awards/ux95.jpg" class="o-collectionImage circle" alt="UX95 user experience award logo">
 						</div>
 						<div class="o-collectionValignWrapper">
 							<div class="o-collectionValignBox">


### PR DESCRIPTION
## Summary
- Add meaningful alt text for all portfolio and award images in source HTML
- Mirror alt descriptions in built distribution HTML for consistency

## Testing
- `npm run build` *(fails: Node Sass does not yet support your current environment: Linux 64-bit with Unsupported runtime (127))*

------
https://chatgpt.com/codex/tasks/task_e_68985ac846008326bcc5dab0eadaa8d4