### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this is
+A static personal portfolio website (Amirhossein Ahmadi). Stack: Grunt build system, Dart Sass, and Materialize CSS. There is no backend — it is served as static files.
+
+### Services / commands
+- Dev server: `yarn serve` (alias for `grunt serve`). Compiles SCSS, copies `src/` → `dist/`, then serves `dist/` on `http://localhost:8000` with `connect` + `watch` livereload. This is a long-running foreground process (keep it running in a background terminal/tmux).
+- Production build: `yarn build` (alias for `grunt build`). Cleans `dist/`, compiles/minifies, and revs assets. Note: running `build` overwrites `dist/`, so re-run `yarn serve` afterwards to restore dev-mode output.
+- Lint/tests: none are configured. `grunt-contrib-jshint`/`grunt-contrib-nodeunit` are installed but no task targets or test files exist, so there is nothing to lint or test.
+
+### Non-obvious gotchas
+- Frontend vendor libraries (materialize, jquery, jquery_lazyload, normalize-css) are installed via **Bower** into `src/vendors/` (gitignored). They are required for both `serve` and `build`: `src/scss/app.scss` imports `materialize/sass/materialize.scss` (via Sass `includePaths`), and `src/index.html` references `vendors/...` JS/CSS. If `src/vendors/` is empty, run `bower install`.
+- Bower is installed globally via `yarn global add bower` but its bin dir (`$(yarn global bin)`, i.e. `~/.yarn/bin`) is not on `PATH` by default. Invoke it as `"$(yarn global bin)/bower"` or add that dir to `PATH` for the session.
+- Bower resolves `jquery` to a 4.x release (Materialize 0.97 only pins `>=2.1.1`). The site renders and is interactive, but very heavy scrolling occasionally crashes the browser tab during headless testing — not an environment setup problem.
+- The `connect` task has `open: true`; in a headless VM it simply fails to launch a browser and keeps serving — harmless.
+- Sass emits many `DEPRECATION WARNING` lines (legacy `@import`, `lighten()/darken()`, `/` division) from the vendored Materialize source. These are warnings only; the build completes successfully.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this static portfolio site (Grunt + Dart Sass + Materialize, with Bower-managed vendor libs) so future Cloud Agents can run and build it out of the box.

## Changes
- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting the stack, dev/build commands, and non-obvious gotchas (Bower vendors in `src/vendors/`, bower not on default `PATH`, jQuery 4 resolution, harmless Sass deprecation warnings, `connect open:true` in headless).
- Configure the environment update script (not in-repo): `yarn install --frozen-lockfile`, `yarn global add bower`, `"$(yarn global bin)/bower" install --config.interactive=false`.

## Verification
- `yarn install` and `bower install` populate deps/vendors successfully.
- `yarn serve` compiles SCSS, copies `src/` → `dist/`, and serves on `http://localhost:8000` (HTTP 200; homepage + `css/app.css`, `js/app.js`, jQuery, Materialize, normalize all 200).
- `yarn build` completes without errors (minifies + revs assets).
- Browsed the running site in Chrome: hero, about, experience, and skills sections render with correct Materialize styling and images; links are interactive.

[portfolio_dev_server_walkthrough.mp4](https://cursor.com/agents/bc-e287bbd3-7b31-4e52-9b71-10e95eb4a694/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_dev_server_walkthrough.mp4)
[Homepage hero](https://cursor.com/agents/bc-e287bbd3-7b31-4e52-9b71-10e95eb4a694/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_homepage.webp)
[Experience section](https://cursor.com/agents/bc-e287bbd3-7b31-4e52-9b71-10e95eb4a694/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_experience.webp)

No application code was modified.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e287bbd3-7b31-4e52-9b71-10e95eb4a694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e287bbd3-7b31-4e52-9b71-10e95eb4a694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

